### PR TITLE
日記投稿一覧画面実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,7 @@
+class PostsController < ApplicationController
+  before_action :require_login
+  
+  def index
+    @posts = current_user.posts.order(created_at: :desc)
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   before_action :require_login
-  
+
   def index
     @posts = current_user.posts.order(created_at: :desc)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,25 +1,2 @@
 module ApplicationHelper
-    def greeting_message
-    hour = Time.current.hour
-    case hour
-    when 5..11
-      "おはようございます"
-    when 12..17
-      "こんにちは"
-    when 18..21
-      "こんばんは"
-    else
-      "お疲れさまでした"
-    end
-  end
-  
-  def motivational_message
-    messages = [
-      "今日はどんな一日でしたか？",
-      "小さな出来事も大切な思い出です",
-      "あなたの日常を記録してみましょう",
-      "今日の気持ちを言葉にしてみませんか？"
-    ]
-    messages.sample
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,25 @@
 module ApplicationHelper
+    def greeting_message
+    hour = Time.current.hour
+    case hour
+    when 5..11
+      "おはようございます"
+    when 12..17
+      "こんにちは"
+    when 18..21
+      "こんばんは"
+    else
+      "お疲れさまでした"
+    end
+  end
+  
+  def motivational_message
+    messages = [
+      "今日はどんな一日でしたか？",
+      "小さな出来事も大切な思い出です",
+      "あなたの日常を記録してみましょう",
+      "今日の気持ちを言葉にしてみませんか？"
+    ]
+    messages.sample
+  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,6 @@
 class Post < ApplicationRecord
   belongs_to :user
-  
+
   validates :title, presence: true, length: { maximum: 255 }
   validates :body, presence: true
-  
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,7 @@
+class Post < ApplicationRecord
+  belongs_to :user
+  
+  validates :title, presence: true, length: { maximum: 255 }
+  validates :body, presence: true
+  
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
+  has_many :posts, dependent: :destroy
+
   validates :first_name, presence: true, length: { maximum: 255 }
   validates :last_name, presence: true, length: { maximum: 255 }
   validates :nick_name, presence: true, length: { maximum: 255 }

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,16 @@
+<h2>あなたの日記記録</h2>
+  
+  <% if @posts.any? %>
+    <% @posts.each do |post| %>
+      <div class="card mb-3">
+        <div class="card-body">
+          <h5 class="card-title"><%= post.title %></h5>
+          <p class="card-text"><%= truncate(post.content, length: 100) %></p>
+          <small class="text-muted"><%= post.created_at.strftime("%Y年%m月%d日") %></small>
+        </div>
+      </div>
+    <% end %>
+  <% else %>
+    <p class="text-center text-muted">まだ日記がありません。</p>
+  <% end %>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -21,9 +21,7 @@
                       class: "nav-link",
                       title: "近日実装予定" %>
           
-          <%= link_to "日記一覧", "#", 
-                      class: "nav-link",
-                      title: "近日実装予定" %>
+          <%= link_to "日記記録", posts_path, class: "nav-link" %>
           
           <%= link_to "プロフィール", "#", 
                       class: "nav-link",

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -32,7 +32,7 @@
     <div class="card h-100">
       <div class="card-body">
         <h5 class="card-text">今までの日記を見てみましょう</h5>
-        <%= link_to '日記投稿を見る', # 投稿一覧_path 
+        <%= link_to '日記投稿を見る', posts_path,
                     class: 'btn btn-success btn-lg w-100' %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,6 @@ Rails.application.routes.draw do
 
   get "up" => "rails/health#show", as: :rails_health_check
 
-  resources :posts, only: [:index]
+  resources :posts, only: [ :index ]
   resources :users, only: %i[new create destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,12 @@
 Rails.application.routes.draw do
   root "static_pages#top"
-
   get "home", to: "static_pages#home"
-
-  resources :users, only: %i[new create destroy]
   get "login", to: "user_sessions#new"
   post "login", to: "user_sessions#create"
   delete "logout", to: "user_sessions#destroy"
 
   get "up" => "rails/health#show", as: :rails_health_check
+
+  resources :posts, only: [:index]
+  resources :users, only: %i[new create destroy]
 end

--- a/db/migrate/20250728090314_create_posts.rb
+++ b/db/migrate/20250728090314_create_posts.rb
@@ -1,0 +1,13 @@
+class CreatePosts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :posts do |t|
+      t.string :title
+      t.text :body
+      t.string :image
+      t.integer :likes_count
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_26_172453) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_28_090314) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "posts", force: :cascade do |t|
+    t.string "title"
+    t.text "body"
+    t.string "image"
+    t.integer "likes_count"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
@@ -25,4 +36,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_26_172453) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
+
+  add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
### 概要
日記投稿一覧画面を実装しました

### 変更点
- Postモデル作成
- '/home'、ヘッダーから'/posts'へリダイレクト遷移
- app/views/posts/index.html.erbで投稿がない場合メッセージ表示の条件分岐

### 参考資料
- chatGOT
- 検討箇所カリキュラム
- qiitaなど