### PR TITLE
日記投稿フォーム実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ add_flash_types :success, :danger
   private
 
   def not_authenticated
-    redirect_to login_path, alert: "ログインしてください"
+    redirect_to login_path, danger: "ログインしてください"
   end
 
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -10,9 +10,9 @@ class PostsController < ApplicationController
   end
 
   def create
-    @post = current_user.new(params)
+    @post = current_user.posts.new(post_params)
     if @post.save
-      redirect_to posts_path, success: '日記を投稿しました！えらい🫶'
+      redirect_to posts_path, notice: '日記を投稿しました！えらい🫶'
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,4 +4,23 @@ class PostsController < ApplicationController
   def index
     @posts = current_user.posts.order(created_at: :desc)
   end
+
+  def new
+    @post = current_user.posts.new
+  end
+
+  def create
+    @post = current_user.new(params)
+    if @post.save
+      redirect_to posts_path, success: '日記を投稿しました！えらい🫶'
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def post_params
+    params.require(:post).permit(:title, :body)
+  end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -12,7 +12,7 @@ class PostsController < ApplicationController
   def create
     @post = current_user.posts.new(post_params)
     if @post.save
-      redirect_to posts_path, notice: '日記を投稿しました！えらい🫶'
+      redirect_to posts_path, notice: "日記を投稿しました！えらい🫶"
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,5 +2,5 @@ class Post < ApplicationRecord
   belongs_to :user
 
   validates :title, presence: true, length: { maximum: 255 }
-  validates :body, presence: true
+  validates :body, presence: true, length: { maximum: 65535 }
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -9,8 +9,8 @@
       <div class="card mb-3">
         <div class="card-body">
           <h5 class="card-title"><%= post.title %></h5>
-          <p class="card-text"><%= truncate(post.content, length: 100) %></p>
-          <small class="text-muted"><%= post.created_at.strftime("%Y年%m月%d日") %></small>
+          <p class="card-text"><%= truncate(post.body, length: 100) %></p>
+          <small class="text-muted"><%= post.created_at.strftime("%Y年%m月%d日 %H:%M") %></small>
         </div>
       </div>
     <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,9 @@
-<h2>あなたの日記記録</h2>
-  
+<div class="container mt-4">
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h2>あなたの日記記録</h2>
+    <%= link_to '新しい日記を書く', new_post_path, class: 'btn btn-primary' %>
+  </div>
+
   <% if @posts.any? %>
     <% @posts.each do |post| %>
       <div class="card mb-3">
@@ -11,6 +15,9 @@
       </div>
     <% end %>
   <% else %>
-    <p class="text-center text-muted">まだ日記がありません。</p>
+    <div class="text-center py-5">
+      <p class="text-muted">まだ日記がありません。</p>
+      <%= link_to '最初の日記を書く', new_post_path, class: 'btn btn-primary' %>
+    </div>
   <% end %>
 </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -36,7 +36,7 @@
                 <!-- 内容入力 -->
                 <div class="mb-4">
                   <%= f.label :content, '内容', class: 'form-label fw-bold' %>
-                  <%= f.text_area :content, 
+                  <%= f.text_area :body, 
                       class: 'form-control', 
                       rows: 12, 
                       placeholder: '今日あったことを自由に書いてください...' %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -3,7 +3,7 @@
   <div class="row justify-content-center">
     <div class="col-lg-10">
       <div class="d-flex justify-content-between align-items-center mb-4">
-        <h1><i class="fas fa-pen"></i> 新しい日記を書く</h1>
+        <h1><i class="fas fa-pen"></i> 🌱新しい日記を書く</h1>
         <%= link_to '← 一覧に戻る', posts_path, class: 'btn btn-outline-secondary' %>
       </div>
       
@@ -33,7 +33,7 @@
                       placeholder: '例：充実した一日 / 新しい発見 / 今日の振り返り' %>
                 </div>
                 
-                <!-- 内容入力 -->
+                <!-- 内容 -->
                 <div class="mb-4">
                   <%= f.label :content, '内容', class: 'form-label fw-bold' %>
                   <%= f.text_area :body, 
@@ -56,7 +56,7 @@
         <div class="col-lg-4">
           <div class="card bg-light">
             <div class="card-header bg-info text-white">
-              <h5 class="mb-0"><i class="fas fa-lightbulb"></i> 書くヒント</h5>
+              <h5 class="mb-0"><i class="fas fa-lightbulb"></i> 日記を書くヒント</h5>
             </div>
             <div class="card-body">
               <h6 class="text-primary">💭 今日はどんな出来事がありましたか？</h6>
@@ -66,7 +66,7 @@
               
               <h6 class="text-success">😊 今の感情は？</h6>
               <p class="small text-muted mb-3">
-                嬉しい、悲しい、驚いた...どんな気持ちでも大丈夫です。
+                嬉しい、悲しい、疲れた...どんな気持ちでも大丈夫です。
               </p>
               
               <h6 class="text-warning">💪 何を頑張りましたか？</h6>
@@ -76,7 +76,7 @@
               
               <h6 class="text-danger">🌟 新しい発見や学びは？</h6>
               <p class="small text-muted mb-3">
-                日常の中にも新しい気づきがあるかもしれません。
+                いつもの日常の中にも新しい気づきがあるかもしれません。
               </p>
               
               <h6 class="text-info">🙏 感謝したいことは？</h6>
@@ -89,10 +89,10 @@
           <!-- メッセージ -->
           <div class="card mt-3">
             <div class="car textd-body-center">
-              <h6 class="text-muted">📝 日記を書くコツ</h6>
+              <h6 class="text-muted">📝 日記を書く意味</h6>
               <p class="small text-m">
-                完璧である必要はありません。<br>
-                思ったことを素直に書くだ丈夫ですけで大！
+                日記を書くことで、感情の整理、自己理解、ストレス軽減ができ、精神的な安定に繋がると言われています😌<br>
+                ささいなことで構いません。今日の自分を振り返ってみましょう。
               </p>
             </div>
           </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,103 @@
+<!-- app/views/posts/new.html.erb -->
+<div class="container mt-4">
+  <div class="row justify-content-center">
+    <div class="col-lg-10">
+      <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1><i class="fas fa-pen"></i> 新しい日記を書く</h1>
+        <%= link_to '← 一覧に戻る', posts_path, class: 'btn btn-outline-secondary' %>
+      </div>
+      
+      <div class="row">
+        <!-- フォーム部分 -->
+        <div class="col-lg-8">
+          <div class="card">
+            <div class="card-body">
+              <%= form_with model: @post, local: true do |f| %>
+                <!-- エラーメッセージ表示 -->
+                <% if @post.errors.any? %>
+                  <div class="alert alert-danger">
+                    <h5><i class="fas fa-exclamation-triangle"></i> 入力内容を確認してください</h5>
+                    <ul class="mb-0">
+                      <% @post.errors.full_messages.each do |message| %>
+                        <li><%= message %></li>
+                      <% end %>
+                    </ul>
+                  </div>
+                <% end %>
+                
+                <!-- タイトル入力 -->
+                <div class="mb-4">
+                  <%= f.label :title, 'タイトル', class: 'form-label fw-bold' %>
+                  <%= f.text_field :title, 
+                      class: 'form-control form-control-lg', 
+                      placeholder: '例：充実した一日 / 新しい発見 / 今日の振り返り' %>
+                </div>
+                
+                <!-- 内容入力 -->
+                <div class="mb-4">
+                  <%= f.label :content, '内容', class: 'form-label fw-bold' %>
+                  <%= f.text_area :content, 
+                      class: 'form-control', 
+                      rows: 12, 
+                      placeholder: '今日あったことを自由に書いてください...' %>
+                </div>
+                
+                <!-- 送信ボタン -->
+                <div class="d-flex justify-content-between">
+                  <%= f.submit '投稿する', class: 'btn btn-primary btn-lg' %>
+                  <%= link_to 'キャンセル', posts_path, class: 'btn btn-secondary' %>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        </div>
+        
+        <!-- 日記の書き方 -->
+        <div class="col-lg-4">
+          <div class="card bg-light">
+            <div class="card-header bg-info text-white">
+              <h5 class="mb-0"><i class="fas fa-lightbulb"></i> 書くヒント</h5>
+            </div>
+            <div class="card-body">
+              <h6 class="text-primary">💭 今日はどんな出来事がありましたか？</h6>
+              <p class="small text-muted mb-3">
+                大きなことでも小さなことでも、印象に残ったことを書いてみましょう。
+              </p>
+              
+              <h6 class="text-success">😊 今の感情は？</h6>
+              <p class="small text-muted mb-3">
+                嬉しい、悲しい、驚いた...どんな気持ちでも大丈夫です。
+              </p>
+              
+              <h6 class="text-warning">💪 何を頑張りましたか？</h6>
+              <p class="small text-muted mb-3">
+                小さな努力や挑戦も立派な頑張りです。
+              </p>
+              
+              <h6 class="text-danger">🌟 新しい発見や学びは？</h6>
+              <p class="small text-muted mb-3">
+                日常の中にも新しい気づきがあるかもしれません。
+              </p>
+              
+              <h6 class="text-info">🙏 感謝したいことは？</h6>
+              <p class="small text-muted mb-0">
+                人や出来事、小さなことにも感謝を見つけてみましょう。
+              </p>
+            </div>
+          </div>
+          
+          <!-- メッセージ -->
+          <div class="card mt-3">
+            <div class="car textd-body-center">
+              <h6 class="text-muted">📝 日記を書くコツ</h6>
+              <p class="small text-m">
+                完璧である必要はありません。<br>
+                思ったことを素直に書くだ丈夫ですけで大！
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -17,7 +17,7 @@
             <%= current_user.nick_name %>さん
           </span>
           
-          <%= link_to "日記投稿", "#", 
+          <%= link_to "日記投稿", new_post_path, 
                       class: "nav-link",
                       title: "近日実装予定" %>
           

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -22,7 +22,7 @@
     <div class="card h-100">
       <div class="card-body">
         <h5 class="card-text">今日の出来事を記録しましょう</h5>
-        <%= link_to '日記投稿をする', # 投稿ページ_path
+        <%= link_to '日記投稿をする', new_post_path,
                     class: 'btn btn-primary btn-lg w-100' %>
       </div>
     </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -22,7 +22,7 @@
             <div class="card-body">
               <h5 class="card-title">既存ユーザー</h5>
               <p class="card-text">アカウントにログインして日記を投稿しましょう！</p>
-              <%= link_to 'ログイン', login_path, 
+              <%= link_to 'ログイン', home_path, 
                           class: 'btn btn-success btn-lg w-100' %>
             </div>
           </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,8 +6,8 @@ module Myapp
   class Application < Rails::Application
     config.load_defaults 8.0
 
-    #日本時間
-    config.time_zone = 'Tokyo'
+    # 日本時間
+    config.time_zone = "Tokyo"
     config.active_record.default_timezone = :local
 
     # 日本語をデフォルトロケールに設定

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,10 @@ module Myapp
   class Application < Rails::Application
     config.load_defaults 8.0
 
+    #日本時間
+    config.time_zone = 'Tokyo'
+    config.active_record.default_timezone = :local
+
     # 日本語をデフォルトロケールに設定
     config.i18n.default_locale = :ja
 
@@ -16,6 +20,7 @@ module Myapp
     config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}")]
   end
 end
+
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/locales/models/user.ja.yml
+++ b/config/locales/models/user.ja.yml
@@ -12,6 +12,9 @@ ja:
         password_confirmation: パスワード確認
         created_at: 登録日時
         updated_at: 更新日時
+      post:
+        title: タイトル
+        body: 内容
     errors:
       models:
         user:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,6 @@ Rails.application.routes.draw do
 
   get "up" => "rails/health#show", as: :rails_health_check
 
-  resources :posts, only: [ :index ]
+  resources :posts, only: %i[index new create]
   resources :users, only: %i[new create destroy]
 end


### PR DESCRIPTION
### 概要
日記投稿フォームを作成し、日記投稿を実装。

### 変更内容
- app/views/posts/new.html.erbを作成し投稿フォームを作成
- 投稿後'/posts'へリダイレクトできる
- エラーメッセージのi18n化
- ヘッダー、'/home'からリダイレクトできる
- フォームにメッセージ表示
- バリデーション設定

### 動作確認
- 各リダイレクト確認
- バリデーション動作確認

### 参考資料
- chatGTP
- qiitaなど