### PR TITLE
日記投稿ページの編集

### DIFF
--- a/app/assets/stylesheets/diary_components.css
+++ b/app/assets/stylesheets/diary_components.css
@@ -1,0 +1,50 @@
+/* ヒントカードの基本スタイル */
+.hint-item {
+  background-color: #ffffff;
+  background-size: 100% 3px;
+  background-repeat: no-repeat;
+  background-position: top;
+}
+
+/* 各ヒントカードの背景グラデーション */
+.hint-item.thought {
+  background-image: linear-gradient(45deg, #f093fb 0%, #f5576c 100%);
+  background-color: #fff8f9;
+}
+
+.hint-item.emotion {
+  background-image: linear-gradient(45deg, #a8edea 0%, #fed6e3 100%);
+  background-color: #f8fff9;
+}
+
+.hint-item.effort {
+  background-image: linear-gradient(45deg, #ffecd2 0%, #fcb69f 100%);
+  background-color: #fffbf8;
+}
+
+.hint-item.discovery {
+  background-image: linear-gradient(45deg, #ff9a9e 0%, #fecfef 100%);
+  background-color: #fff8fb;
+}
+
+/* カードヘッダーのグラデーション */
+.card-header.diary-gradient {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  border: none;
+}
+
+/* メッセージカードのグラデーション */
+.message-card-body {
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  border-radius: 0.375rem;
+}
+
+/* ヒントアイコンのスタイル */
+.hint-icon .badge {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+}

--- a/app/assets/stylesheets/posts_layout.css
+++ b/app/assets/stylesheets/posts_layout.css
@@ -3,7 +3,6 @@ body {
   min-height: 100vh;
   font-family: 'ヒラギノ丸ゴ ProN','Hiragino Maru Gothic ProN', 
 sans-serif;
-
 }
 
 /* カード背景 */

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,5 @@
 <link rel="stylesheet" href="/assets/likes_counter.css">
-<link rel="stylesheet" href="/assets/posts_layout.css">
+
 
 <div class="container mt-4">
   <div class="d-flex justify-content-between align-items-center mb-4">
@@ -20,7 +20,7 @@
             </div>
 
           <!-- 投稿内容 -->
-          <p class="card-text mb-3"><%= truncate(post.body, length: 100) %></p>
+          <p class="card-text me-2 fs-6 px-3 py-2 mb-3"><%= truncate(post.body, length: 100) %></p>
 
           <div class="d-flex justify-content-between align-items-center">
             <!-- ユーザーアイコンと名前をセット -->

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -60,7 +60,7 @@
 <%= stylesheet_link_tag 'diary_components', 'data-turbolinks-track': 'reload' %>
 
 <div class="col-lg-4">
-  <div class="card border-0 shadow-sm mb-3 rounded-3">
+  <div class="card border-0 shadow-sm mb-4 rounded-3">
       <!-- ヒントカード：今日の出来事 -->
       <div class="hint-item thought mb-0 p-4 rounded">
         <div class="d-flex align-items-start">
@@ -95,7 +95,7 @@
           </div>
           <div>
             <h6 class="text-warning fw-bold mb-1">何を頑張りましたか？</h6>
-            <p class="small text-muted mb-0">小さな努力や挑戦も立派な頑張りです。</p>
+            <p class="small text-muted mb-0">朝早く起きた、会社へ向かった。小さな努力や挑戦も立派な頑張りです。</p>
           </div>
         </div>
       </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,7 +1,7 @@
 <!-- app/views/posts/new.html.erb -->
 <div class="container mt-4">
   <div class="row justify-content-center">
-    <div class="col-lg-10">
+    <div class="col-lg-12">
       <div class="d-flex justify-content-between align-items-center mb-4">
         <h1><i class="fas fa-pen"></i> 🌱新しい日記を書く</h1>
         <%= link_to '← 一覧に戻る', posts_path, class: 'btn btn-outline-secondary' %>
@@ -10,7 +10,7 @@
       <div class="row">
         <!-- フォーム部分 -->
         <div class="col-lg-8">
-          <div class="card">
+          <div class="card mb-4">
             <div class="card-body">
               <%= form_with model: @post, local: true do |f| %>
                 <!-- エラーメッセージ表示 -->
@@ -34,16 +34,16 @@
                   <%= f.label :title, 'タイトル', class: 'form-label fw-bold' %>
                   <%= f.text_field :title, 
                       class: 'form-control form-control-lg', 
-                      placeholder: '例：充実した一日 / 新しい発見 / 今日の振り返り' %>
+                      placeholder: '例：充実した一日 / 〇〇に挑戦！ / 今日の振り返り' %>
                 </div>
                 
                 <!-- 内容 -->
                 <div class="mb-4">
-                  <%= f.label :content, '内容', class: 'form-label fw-bold' %>
+                  <%= f.label :body, '内容', class: 'form-label fw-bold' %>
                   <%= f.text_area :body, 
                       class: 'form-control', 
                       rows: 12, 
-                      placeholder: '今日あったことを自由に書いてください...' %>
+                      placeholder: '今日あったことを自由に書いてみましょう' %>
                 </div>
                 
                 <!-- 送信ボタン -->
@@ -55,53 +55,75 @@
             </div>
           </div>
         </div>
-        
-        <!-- 日記の書き方 -->
-        <div class="col-lg-4">
-          <div class="card bg-light">
-            <div class="card-header bg-info text-white">
-              <h5 class="mb-0"><i class="fas fa-lightbulb"></i> 日記を書くヒント</h5>
-            </div>
-            <div class="card-body">
-              <h6 class="text-primary">💭 今日はどんな出来事がありましたか？</h6>
-              <p class="small text-muted mb-3">
-                大きなことでも小さなことでも、印象に残ったことを書いてみましょう。
-              </p>
-              
-              <h6 class="text-success">😊 今の感情は？</h6>
-              <p class="small text-muted mb-3">
-                嬉しい、悲しい、疲れた...どんな気持ちでも大丈夫です。
-              </p>
-              
-              <h6 class="text-warning">💪 何を頑張りましたか？</h6>
-              <p class="small text-muted mb-3">
-                小さな努力や挑戦も立派な頑張りです。
-              </p>
-              
-              <h6 class="text-danger">🌟 新しい発見や学びは？</h6>
-              <p class="small text-muted mb-3">
-                いつもの日常の中にも新しい気づきがあるかもしれません。
-              </p>
-              
-              <h6 class="text-info">🙏 感謝したいことは？</h6>
-              <p class="small text-muted mb-0">
-                人や出来事、小さなことにも感謝を見つけてみましょう。
-              </p>
-            </div>
+
+<!-- メッセージ -->
+<%= stylesheet_link_tag 'diary_components', 'data-turbolinks-track': 'reload' %>
+
+<div class="col-lg-4">
+  <div class="card border-0 shadow-sm mb-3 rounded-3">
+      <!-- ヒントカード：今日の出来事 -->
+      <div class="hint-item thought mb-0 p-4 rounded">
+        <div class="d-flex align-items-start">
+          <div class="hint-icon me-3">
+            <span class="badge bg-primary rounded-circle p-2">💭</span>
           </div>
-          
-          <!-- メッセージ -->
-          <div class="card mt-3">
-            <div class="car textd-body-center">
-              <h6 class="text-muted">📝 日記を書く意味</h6>
-              <p class="small text-m">
-                日記を書くことで、感情の整理、自己理解、ストレス軽減ができ、精神的な安定に繋がると言われています😌<br>
-                ささいなことで構いません。今日の自分を振り返ってみましょう。
-              </p>
-            </div>
+          <div>
+            <h6 class="text-primary fw-bold mb-1">今日はどんな出来事がありましたか？</h6>
+            <p class="small text-muted mb-0">大きなことでも小さなことでも、印象に残ったことを書いてみましょう。</p>
           </div>
         </div>
       </div>
+      
+      <!-- ヒントカード：感情 -->
+      <div class="hint-item emotion mb-0 p-4 rounded">
+        <div class="d-flex align-items-start">
+          <div class="hint-icon me-3">
+            <span class="badge bg-success rounded-circle p-2">😊</span>
+          </div>
+          <div>
+            <h6 class="text-success fw-bold mb-1">今の感情は？</h6>
+            <p class="small text-muted mb-0">嬉しい、悲しい、疲れた...どんな気持ちでも大丈夫です。</p>
+          </div>
+        </div>
+      </div>
+      
+      <!-- ヒントカード：頑張ったこと -->
+      <div class="hint-item effort mb-0 p-4 rounded">
+        <div class="d-flex align-items-start">
+          <div class="hint-icon me-3">
+            <span class="badge bg-warning rounded-circle p-2">🔥</span>
+          </div>
+          <div>
+            <h6 class="text-warning fw-bold mb-1">何を頑張りましたか？</h6>
+            <p class="small text-muted mb-0">小さな努力や挑戦も立派な頑張りです。</p>
+          </div>
+        </div>
+      </div>
+      
+      <!-- ヒントカード：新しい発見 -->
+      <div class="hint-item discovery mb-0 p-4 rounded">
+        <div class="d-flex align-items-start">
+          <div class="hint-icon me-3">
+            <span class="badge bg-danger rounded-circle p-2">🌟</span>
+          </div>
+          <div>
+            <h6 class="text-danger fw-bold mb-1">新しい発見や学びは？</h6>
+            <p class="small text-muted mb-0">いつもの日常の中にも新しい気づきがあるかもしれません。</p>
+          </div>
+        </div>
+      </div>
+  </div>
+  
+  <!-- メッセージカード -->
+  <div class="card border-0 shadow-sm mb-4">
+    <div class="card-body text-center p-4 message-card-body">
+      <div class="mb-3">
+        <i class="fas fa-heart text-white" style="font-size: 2rem;"></i>
+      </div>
+      <h6 class="text-white fw-bold mb-4">💝 いいねの秘密</h6>
+      <p class="text-white-50 small mb-0">
+        自分の感情を素直に書き出すと<br>
+        たくさんいいねがつくかも、、、✨✨ </p>
     </div>
   </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -12,14 +12,22 @@
       <div class="navbar-nav ms-auto">
         <% if logged_in? %>
           <!-- ログイン済みの場合 -->
-          <span class="nav-link text-muted">
-            <i class="fas fa-user me-1"></i>
-            <%= image_tag current_user.profile_image, 
-                      class: "rounded-circle me-1", 
-                      style: "width: 24px; height: 24px; object-fit: cover;" %>
+          <span class="navbar-text d-flex align-items-center">
+            <% if current_user.profile_image.present? %>
+              <%= image_tag current_user.profile_image, 
+                  class: "rounded-circle me-2", 
+                  style: "width: 32px; height: 32px; object-fit: cover;" %>
+            <% else %>
+              <div class="rounded-circle bg-light d-flex align-items-center justify-content-center me-2"
+                  style="width: 32px; height: 32px;">
+                <i class="fas fa-user text-muted" style="font-size: 14px;"></i>
+              </div>
+            <% end %>
             <%= current_user.nick_name %>さん
           </span>
           
+
+        <div class="navbar-text d-flex align-items-center">
           <%= link_to "日記投稿", new_post_path, 
                       class: "nav-link",
                       title: "日記投稿" %>
@@ -36,6 +44,7 @@
                       class: "nav-link text-danger",
                       data: { confirm: "本当にログアウトしますか？" } %>
         <% end %>
+        </div>
       </div>
     </div>
   </div>

--- a/compose.yml
+++ b/compose.yml
@@ -6,7 +6,7 @@ services: # コンテナの定義開始
       TZ: Asia/Tokyo # タイムゾーンを日本に設定
       POSTGRES_PASSWORD: password # データベースのパスワード設定
     volumes: # データの永続化設定
-      - postgresql_data:/var/lib/postgresql # DBデータを永続化
+      - postgresql_data:/var/lib/postgresql/data # DBデータを永続化
     ports: # ポート設定
       - 5432:5432
     healthcheck: # コンテナの健康チェック設定


### PR DESCRIPTION
### 概要
日記投稿ページのレイアウト、デザインを編集しました。

### 変更内容
- compose.ymlでvolumes設定
- app/assets/stylesheets/diary_components.cssでデザインを編集
- app/views/posts/new.html.erbでbootstrapを使いレイアウト調整

### 動作確認
- 正常に投稿できる
- レイアウト崩れがない

### 参考資料
- chatGPT
- bootstrap公式リファレンス