### PR TITLE
管理者画面の作成

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,22 @@
+class Admin::UsersController < ApplicationController
+  before_action :require_login
+  before_action :require_admin
+
+  def index
+    @users = User.all
+  end
+
+  def destroy
+    user = User.find(params[:id])
+    user.destroy
+    redirect_to admin_users_path, notice: "ユーザーを削除しました"
+  end
+
+  private
+
+  def require_admin
+    unless current_user&.admin?
+      redirect_to root_path, alert: "管理者のみアクセスできます"
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+include Sorcery::Controller
 before_action :require_login
 
 add_flash_types :success, :danger

--- a/app/views/admin/users/destroy.html.erb
+++ b/app/views/admin/users/destroy.html.erb
@@ -1,0 +1,2 @@
+<h1>Admin::Users#destroy</h1>
+<p>Find me in app/views/admin/users/destroy.html.erb</p>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,33 @@
+<h1>ユーザー一覧</h1>
+
+<table class="table table-bordered">
+  <thead>
+    <tr>
+      <th>名前</th>
+      <th>メールアドレス</th>
+      <th>操作</th>
+    </tr>
+  </thead>
+  <tbody>
+  <% @users.each do |user| %>
+    <tr>
+      <td><%= user.nick_name %></td>
+      <td><%= user.email %></td>
+      <td>
+        <% if user == current_user %>
+          <small>(自分自身)</small>
+        <% else %>
+          <%= link_to admin_user_path(user),
+                      class: "btn btn-danger btn-sm",
+                      data: {
+                        turbo_method: :delete,
+                        turbo_confirm: "本当に削除しますか？"
+                      } do %>
+            <i class="bi bi-trash"></i> 削除
+          <% end %>
+        <% end %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -3,6 +3,8 @@
 <table class="table table-bordered">
   <thead>
     <tr>
+      <th>姓</th>
+      <th>名</th>
       <th>名前</th>
       <th>メールアドレス</th>
       <th>操作</th>
@@ -12,6 +14,8 @@
   <% @users.each do |user| %>
     <tr>
       <td><%= user.nick_name %></td>
+      <td><%= user.first_name %></td>
+      <td><%= user.last_name %></td>
       <td><%= user.email %></td>
       <td>
         <% if user == current_user %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,4 +13,8 @@ Rails.application.routes.draw do
   resources :posts, only: %i[index new create show edit destroy update]
   resources :users, only: %i[new create destroy]
   resource :profile, only: %i[show edit update]
+
+  namespace :admin do
+    resources :users, only: %i[index destroy]
+  end
 end

--- a/db/migrate/20250805081327_add_admin_to_users.rb
+++ b/db/migrate/20250805081327_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :admin, :boolean
+  end
+end


### PR DESCRIPTION
### 概要
管理者画面を作成し、ユーザーの管理をできるようにしました。
機能はユーザーの削除だけで、投稿はプライベートなもののため見れないようにしています（SNSシェア機能を作成した場合、シェア投稿だけ取得し、削除できるように追加する予定です）

### 変更内容
- adminデレクトリ、ファイルを作成し記述
- sorceryのみで実装
- admin画面はapp/views/admin/users/index.html.erbのみ
- 管理者は自分のみの設定
- 個人開発のためbooleanで管理

### 動作確認
- 管理者以外のアカウントはadminに入れない
- ユーザー削除ができる

### 参考資料
- chatGPT
- 該当カリキュラム