### PR TITLE
使い方ページ実装

### DIFF
--- a/app/views/admin/shared_posts/index.html.erb
+++ b/app/views/admin/shared_posts/index.html.erb
@@ -17,11 +17,7 @@
           <td><%= post.user.nick_name %></td>
           <td><%= post.title %></td>
           <td><%= post.body %></td>
-          <td>
-            <%= link_to shared_post_url(post.share_token, host: 'd4bc3ac321f7.ngrok-free.app'), target: "_blank"  do %>
-              シェアリンク
-            <% end %>
-          </td>
+          <td><%= post.created_at %></td>
           <td>
       <%= link_to '削除', admin_shared_post_path(post), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: "btn btn-danger btn-sm" %>          </td>
         </tr>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -43,7 +43,7 @@
                   <%= f.text_area :body, 
                       class: 'form-control', 
                       rows: 12, 
-                      placeholder: '自分の感情や出来事を書き出すことで、ストレスを軽減し、精神的安定につながると言われています。' %>
+                      placeholder: '思ったこと、感じたこと、自由に書いてみましょう' %>
                 </div>
                 
                 <!-- 送信ボタン -->

--- a/app/views/shared/_usage.html.erb
+++ b/app/views/shared/_usage.html.erb
@@ -6,15 +6,15 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
       </div>
       <div class="modal-body">
-        <p><strong class="text-primary">① 日記投稿をする</strong> — 「日記投稿をする」ボタンを押すとフォームが開き、今日の出来事や気持ちを書き残せます。</p>
-        <p><strong class="text-primary">② 日記一覧を見る</strong> — 「日記を見る」ボタンからこれまでの日記を振り返ることができます。</p>
-        <p><strong class="text-primary">③ シェア機能</strong> — 日記一覧や詳細画面からXにシェア投稿ができます。<br>
+        <p><strong class="text-primary">① 日記投稿をする</strong> - 「日記投稿をする」ボタンを押すとフォームが開き、今日の出来事や気持ちを書き残せます。</p>
+        <p><strong class="text-primary">② 日記一覧を見る</strong> - 「日記を見る」ボタンからこれまでの日記を振り返ることができます。</p>
+        <p><strong class="text-primary">③ シェア機能</strong> - 日記一覧や詳細画面からXにシェア投稿ができます。<br>
         日々の頑張りや小さな喜びを、誰かと分かち合ってみましょう。</p>
         <p><strong class="text-primary">④ プロフィール</strong> - ヘッダーのプロフィールからニックネームとユーザー画像を変更できます。<br>(※シェア投稿で、ニックネーム、ユーザー画像が表示されます)
-        <p><strong class="text-primary">⑤ ログアウト</strong> — ヘッダー右上のメニューからいつでもログアウトできます。</p>
-        <p><strong class="text-success">📝 日記について</strong> — 日記は日々の出来事だけでなく、その時の気持ちもそっと残せる場所です。<br>
+        <p><strong class="text-primary">⑤ ログアウト</strong> - ヘッダー右上のメニューからいつでもログアウトできます。</p>
+        <p><strong class="text-success">📝 日記について</strong> - 日記は日々の出来事だけでなく、その時の気持ちもそっと残せる場所です。<br>
         言葉にすることで心が整理され、気持ちがやわらぎ、穏やかな時間につながります。</p>
-        <p><strong class="text-success">📔 このアプリのヒント</strong> — あなたの日記はあなただけの大切な記録。管理者を含め、誰にも見られることはありません。<br>
+        <p><strong class="text-success">📔 このアプリのヒント</strong> - あなたの日記はあなただけの大切な記録。管理者を含め、誰にも見られることはありません。<br>
         安心して思ったことや感じたことを自由に書き出してください。（※シェア投稿のみ内容が取得されます）</p>
       </div>
       <div class="modal-footer">

--- a/app/views/shared/_usage.html.erb
+++ b/app/views/shared/_usage.html.erb
@@ -1,0 +1,24 @@
+<div class="modal fade" id="usage" tabindex="-1" aria-labelledby="usageLabel" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title bg-success opacity-75 text-white" id="usageLabel">使い方</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="閉じる"></button>
+      </div>
+      <div class="modal-body">
+        <p><strong class="text-primary">① 日記投稿をする</strong> — 「日記投稿をする」ボタンを押すとフォームが開き、今日の出来事や気持ちを書き残せます。</p>
+        <p><strong class="text-primary">② 日記一覧を見る</strong> — 「日記を見る」ボタンから、これまでの日記を振り返ることができます。</p>
+        <p><strong class="text-primary">③ シェア機能</strong> — 日記一覧や詳細画面からXにシェア投稿ができます。<br>
+        日々の頑張りや小さな喜びを、誰かと分かち合ってみましょう。</p>
+        <p><strong class="text-primary">④ ログアウト</strong> — ヘッダー右上のメニューから、いつでもログアウトできます。</p>
+        <p><strong class="text-success">📝 日記について</strong> — 日記は、日々の出来事だけでなく、その時の気持ちもそっと残せる場所です。<br>
+        言葉にすることで心が整理され、気持ちがやわらぎ、穏やかな時間につながります。</p>
+        <p><strong class="text-success">📔 このアプリのヒント</strong> — あなたの日記は、あなただけの大切な記録。管理者を含め、誰にも見られることはありません。<br>
+        安心して、思ったことや感じたことを自由に書き出してください。（※シェア投稿のみ内容が取得されます）</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">閉じる</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_usage.html.erb
+++ b/app/views/shared/_usage.html.erb
@@ -1,4 +1,4 @@
-<div class="modal fade" id="usage" tabindex="-1" aria-labelledby="usageLabel" aria-hidden="true">
+<div class="modal fade" id="usageModal" tabindex="-1" aria-labelledby="usageLabel" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
@@ -7,14 +7,15 @@
       </div>
       <div class="modal-body">
         <p><strong class="text-primary">① 日記投稿をする</strong> — 「日記投稿をする」ボタンを押すとフォームが開き、今日の出来事や気持ちを書き残せます。</p>
-        <p><strong class="text-primary">② 日記一覧を見る</strong> — 「日記を見る」ボタンから、これまでの日記を振り返ることができます。</p>
+        <p><strong class="text-primary">② 日記一覧を見る</strong> — 「日記を見る」ボタンからこれまでの日記を振り返ることができます。</p>
         <p><strong class="text-primary">③ シェア機能</strong> — 日記一覧や詳細画面からXにシェア投稿ができます。<br>
         日々の頑張りや小さな喜びを、誰かと分かち合ってみましょう。</p>
-        <p><strong class="text-primary">④ ログアウト</strong> — ヘッダー右上のメニューから、いつでもログアウトできます。</p>
-        <p><strong class="text-success">📝 日記について</strong> — 日記は、日々の出来事だけでなく、その時の気持ちもそっと残せる場所です。<br>
+        <p><strong class="text-primary">④ プロフィール</strong> - ヘッダーのプロフィールからニックネームとユーザー画像を変更できます。<br>(※シェア投稿で、ニックネーム、ユーザー画像が表示されます)
+        <p><strong class="text-primary">⑤ ログアウト</strong> — ヘッダー右上のメニューからいつでもログアウトできます。</p>
+        <p><strong class="text-success">📝 日記について</strong> — 日記は日々の出来事だけでなく、その時の気持ちもそっと残せる場所です。<br>
         言葉にすることで心が整理され、気持ちがやわらぎ、穏やかな時間につながります。</p>
-        <p><strong class="text-success">📔 このアプリのヒント</strong> — あなたの日記は、あなただけの大切な記録。管理者を含め、誰にも見られることはありません。<br>
-        安心して、思ったことや感じたことを自由に書き出してください。（※シェア投稿のみ内容が取得されます）</p>
+        <p><strong class="text-success">📔 このアプリのヒント</strong> — あなたの日記はあなただけの大切な記録。管理者を含め、誰にも見られることはありません。<br>
+        安心して思ったことや感じたことを自由に書き出してください。（※シェア投稿のみ内容が取得されます）</p>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">閉じる</button>

--- a/app/views/shared/_usage.html.erb
+++ b/app/views/shared/_usage.html.erb
@@ -23,3 +23,5 @@
     </div>
   </div>
 </div>
+
+<script src="/usage.js"></script>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -20,7 +20,8 @@
             <p class="card-text mb-2">アプリの使い方を確認しましょう</p>
             <button type="button" class="btn btn-success opacity-75 text-white" 
                     data-bs-toggle="modal" 
-                    data-bs-target="#usageModal">
+                    data-bs-target="#usageModal"
+                    data-bs-focus="false">
               使い方をみる
             </button>
           </div>
@@ -58,3 +59,4 @@
       </div>
     </div>
   </div>
+  

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -12,22 +12,24 @@
     </div>
 
   <div class="home-container">
-    <!-- 下部左右：投稿・閲覧ボタン -->
     <div class="bottom-buttons text-center">
       <div class="mb-4" style="max-width: 300px; margin: 0 auto;">
         <div class="card h-100 border-success opacity-75 p-2" style="font-size: 0.9rem;">
           <div class="card-body text-center p-2">
             <h6 class="card-title mb-2"><span>🔰</span> 使い方</h6>
             <p class="card-text mb-2">アプリの使い方を確認しましょう</p>
-            <%= link_to '使い方を見る', '#', class: 'btn btn-success text-white btn-sm w-100' %>
+            <button type="button" class="btn btn-success opacity-75 text-white" data-bs-toggle="modal" data-bs-target="#usage">
+              使い方を開く
+            </button>
           </div>
         </div>
       </div>
     </div>
   </div>
 
+  <%= render "shared/usage" %>
+
   <div class="home-container">
-    <!-- 下部左右：投稿・閲覧ボタン -->
     <div class="bottom-buttons">
       <div class="flex-fill mb-4 px-4">
         <div class="card h-100 border-primary opacity-75">

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -18,8 +18,10 @@
           <div class="card-body text-center p-2">
             <h6 class="card-title mb-2"><span>🔰</span> 使い方</h6>
             <p class="card-text mb-2">アプリの使い方を確認しましょう</p>
-            <button type="button" class="btn btn-success opacity-75 text-white" data-bs-toggle="modal" data-bs-target="#usage">
-              使い方を開く
+            <button type="button" class="btn btn-success opacity-75 text-white" 
+                    data-bs-toggle="modal" 
+                    data-bs-target="#usageModal">
+              使い方をみる
             </button>
           </div>
         </div>
@@ -27,7 +29,7 @@
     </div>
   </div>
 
-  <%= render "shared/usage" %>
+              <%= render 'shared/usage' %>
 
   <div class="home-container">
     <div class="bottom-buttons">

--- a/public/usage.js
+++ b/public/usage.js
@@ -1,0 +1,109 @@
+<!-- aria-hidden属性とフォーカスの競合 モーダル1つのみのためhtml埋め込み -->
+document.addEventListener('DOMContentLoaded', function() {
+  const usageModal = document.getElementById('usageModal');
+  
+  if (usageModal) {
+    usageModal.addEventListener('hide.bs.modal', function() {
+      if (document.activeElement !== document.body) {
+        document.activeElement.blur();
+      }
+    });
+  }
+});
+
+
+
+
+<!-- 背景色クリーンアップ -->
+document.addEventListener('turbo:load', function() {
+  console.log('🔧 Page loaded - Setup modal handlers');
+  
+  const usageModal = document.getElementById('usageModal');
+  
+  if (usageModal) {
+    // モーダルが開いた時
+    usageModal.addEventListener('show.bs.modal', function() {
+      console.log('✅ Modal opening...');
+    });
+    
+    // モーダルが完全に開いた時
+    usageModal.addEventListener('shown.bs.modal', function() {
+      console.log('✅ Modal opened successfully');
+    });
+    
+    // モーダルが閉じる瞬間
+    usageModal.addEventListener('hide.bs.modal', function() {
+      console.log('🔧 Modal hiding - Starting cleanup');
+    });
+    
+    // モーダルが完全に閉じた後にクリーンアップ
+    usageModal.addEventListener('hidden.bs.modal', function() {
+      console.log('🔧 Modal hidden - Force cleanup');
+      setTimeout(forceModalCleanup, 200);
+    });
+  }
+});
+
+// ページ遷移前の強制クリーンアップ
+document.addEventListener('turbo:before-visit', function() {
+  console.log('🔧 Page leaving - Force cleanup');
+  forceModalCleanup();
+});
+
+// 強制クリーンアップ関数
+function forceModalCleanup() {
+  console.log('🧹 Executing force cleanup...');
+  
+  document.body.classList.remove('modal-open');
+  document.body.style.overflow = '';
+  document.body.style.paddingRight = '';
+  document.body.style.backgroundColor = '';
+  
+  const backdrops = document.querySelectorAll('.modal-backdrop');
+  backdrops.forEach(backdrop => {
+    console.log('🗑️ Removing backdrop:', backdrop);
+    backdrop.remove();
+  });
+  
+  const modals = document.querySelectorAll('.modal');
+  modals.forEach(modal => {
+    if (!modal.classList.contains('show')) {
+      modal.style.display = 'none';
+      modal.setAttribute('aria-hidden', 'true');
+    }
+  });
+  
+  console.log('✅ Force cleanup completed');
+  console.log('Body classes:', document.body.className);
+  console.log('Remaining backdrops:', document.querySelectorAll('.modal-backdrop').length);
+}
+
+// 修正された監視機能（開発時のみ）
+if (window.location.hostname === 'localhost') {
+  setInterval(function() {
+    const activeModals = document.querySelectorAll('.modal.show').length;
+    const backdropsCount = document.querySelectorAll('.modal-backdrop').length;
+    const hasModalOpen = document.body.classList.contains('modal-open');
+    
+    // 🔧 修正：アクティブなモーダルがあるのに背景が複数ある場合のみ異常と判定
+    if (activeModals > 0 && backdropsCount > 1) {
+      console.warn('⚠️ Multiple backdrops detected with active modal - Cleaning excess');
+      console.log('active modals:', activeModals);
+      console.log('backdrops:', backdropsCount);
+      
+      // 余分な背景のみ削除（最初の1つは残す）
+      const backdrops = document.querySelectorAll('.modal-backdrop');
+      for (let i = 1; i < backdrops.length; i++) {
+        console.log('🗑️ Removing excess backdrop:', backdrops[i]);
+        backdrops[i].remove();
+      }
+    }
+    // アクティブなモーダルがないのに残骸がある場合
+    else if (activeModals === 0 && (hasModalOpen || backdropsCount > 0)) {
+      console.warn('⚠️ Modal remnants detected (no active modals) - Auto cleanup');
+      console.log('modal-open:', hasModalOpen);
+      console.log('backdrops:', backdropsCount);
+      forceModalCleanup();
+    }
+  }, 1000); // 1秒ごとにチェック
+}


### PR DESCRIPTION
### 概要
使い方ページを実装し、モーダルで「使い方をみる」ボタンから表示できるようにしています。

### 変更内容
- Bootstrapの標準機能でモーダルを作成
- jsでクリーンアップを追加
- /homeにrenderで表示

### 動作確認
- 正常に動作する
- モーダル表示中の背景が変わらない

### 参考資料
- chatGPT
- その他サイト