### PR TITLE
dbをpostgreSQLのみに設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,8 +13,6 @@ module Myapp
     config.solid_queue.silence_polling = true
     config.active_job.queue_adapter = :inline
 
-    config.cache_store = :memory_store
-
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.


### PR DESCRIPTION
### 概要
デプロイエラーの根源の
gem "solid_cache"
gem "solid_queue"
gem "solid_cable
を削除し、postgreSQLのみでdb管理